### PR TITLE
Migrate to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ and Redox by leveraging the mechanisms defined by the XDG base/user
 directory specifications on Linux, the Known Folder API on Windows,
 and the Standard Directory guidelines on macOS.
 """
+edition     = "2018"
 readme      = "README.md"
 license     = "MIT OR Apache-2.0"
 repository  = "https://github.com/xdg-rs/dirs"

--- a/directories/Cargo.toml
+++ b/directories/Cargo.toml
@@ -9,6 +9,7 @@ leveraging the mechanisms defined by the XDG base/user directory specifications
 on Linux, the Known Folder API on Windows, and the Standard Directory guidelines
 on macOS.
 """
+edition     = "2018"
 readme      = "README.md"
 license     = "MIT OR Apache-2.0"
 repository  = "https://github.com/xdg-rs/dirs/tree/master/directories"

--- a/directories/benches/constructors.rs
+++ b/directories/benches/constructors.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate bencher;
-extern crate directories_next;
-
+use bencher::{benchmark_group, benchmark_main};
 use bencher::Bencher;
 use bencher::black_box;
 use directories_next::BaseDirs;

--- a/directories/src/lib.rs
+++ b/directories/src/lib.rs
@@ -13,9 +13,9 @@
 //!
 
 #![deny(missing_docs)]
+#![warn(rust_2018_idioms)]
 
-#[macro_use]
-extern crate cfg_if;
+use cfg_if::cfg_if;
 
 use std::path::Path;
 use std::path::PathBuf;
@@ -32,7 +32,7 @@ cfg_if! {
         use wasm as sys;
     } else {
         mod lin;
-        use lin as sys;
+        use crate::lin as sys;
     }
 }
 
@@ -441,21 +441,21 @@ impl ProjectDirs {
 mod tests {
     #[test]
     fn test_base_dirs() {
-        println!("BaseDirs::new())\n{:?}", ::BaseDirs::new());
+        println!("BaseDirs::new())\n{:?}", crate::BaseDirs::new());
     }
 
     #[test]
     fn test_user_dirs() {
-        println!("UserDirs::new())\n{:?}", ::UserDirs::new());
+        println!("UserDirs::new())\n{:?}", crate::UserDirs::new());
     }
 
     #[test]
     fn test_project_dirs() {
-        let proj_dirs = ::ProjectDirs::from("qux", "FooCorp", "BarApp");
+        let proj_dirs = crate::ProjectDirs::from("qux", "FooCorp", "BarApp");
         println!("ProjectDirs::from(\"qux\", \"FooCorp\", \"BarApp\")\n{:?}", proj_dirs);
-        let proj_dirs = ::ProjectDirs::from("qux.zoo", "Foo Corp", "Bar-App");
+        let proj_dirs = crate::ProjectDirs::from("qux.zoo", "Foo Corp", "Bar-App");
         println!("ProjectDirs::from(\"qux.zoo\", \"Foo Corp\", \"Bar-App\")\n{:?}", proj_dirs);
-        let proj_dirs = ::ProjectDirs::from("com", "Foo Corp.", "Bar App");
+        let proj_dirs = crate::ProjectDirs::from("com", "Foo Corp.", "Bar App");
         println!("ProjectDirs::from(\"com\", \"Foo Corp.\", \"Bar App\")\n{:?}", proj_dirs);
     }
 }

--- a/directories/src/lin.rs
+++ b/directories/src/lin.rs
@@ -1,11 +1,9 @@
-extern crate dirs_sys_next;
-
 use std::env;
 use std::path::PathBuf;
 
-use BaseDirs;
-use UserDirs;
-use ProjectDirs;
+use crate::BaseDirs;
+use crate::UserDirs;
+use crate::ProjectDirs;
 
 pub fn base_dirs() -> Option<BaseDirs> {
     if let Some(home_dir)  = dirs_sys_next::home_dir() {
@@ -101,7 +99,7 @@ fn trim_and_lowercase_then_replace_spaces(name: &str, replacement: &str) -> Stri
 
 #[cfg(test)]
 mod tests {
-    use lin::trim_and_lowercase_then_replace_spaces;
+    use crate::lin::trim_and_lowercase_then_replace_spaces;
 
     #[test]
     fn test_trim_and_lowercase_then_replace_spaces() {
@@ -128,7 +126,7 @@ mod tests {
 
     #[test]
     fn test_file_user_dirs_exists() {
-        let base_dirs      = ::BaseDirs::new();
+        let base_dirs      = crate::BaseDirs::new();
         let user_dirs_file = base_dirs.unwrap().config_dir().join("user-dirs.dirs");
         println!("{:?} exists: {:?}", user_dirs_file, user_dirs_file.exists());
     }

--- a/directories/src/mac.rs
+++ b/directories/src/mac.rs
@@ -1,10 +1,8 @@
-extern crate dirs_sys_next;
-
 use std::path::PathBuf;
 
-use BaseDirs;
-use UserDirs;
-use ProjectDirs;
+use crate::BaseDirs;
+use crate::UserDirs;
+use crate::ProjectDirs;
 
 pub fn base_dirs() -> Option<BaseDirs> {
     if let Some(home_dir)  = dirs_sys_next::home_dir() {

--- a/directories/src/win.rs
+++ b/directories/src/win.rs
@@ -1,11 +1,9 @@
-extern crate dirs_sys_next;
-
 use std::path::PathBuf;
 use std::iter::FromIterator;
 
-use BaseDirs;
-use UserDirs;
-use ProjectDirs;
+use crate::BaseDirs;
+use crate::UserDirs;
+use crate::ProjectDirs;
 
 pub fn base_dirs() -> Option<BaseDirs> {
     let home_dir       = dirs_sys_next::known_folder_profile();

--- a/dirs-sys/Cargo.toml
+++ b/dirs-sys/Cargo.toml
@@ -3,6 +3,7 @@ name        = "dirs-sys-next"
 version     = "0.1.0"
 authors     = ["The @xdg-rs members"]
 description = "system-level helper functions for the dirs and directories crates"
+edition     = "2018"
 readme      = "README.md"
 license     = "MIT OR Apache-2.0"
 repository  = "https://github.com/xdg-rs/dirs/tree/master/dirs-sys"

--- a/dirs-sys/src/lib.rs
+++ b/dirs-sys/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(rust_2018_idioms)]
+
 use std::ffi::OsString;
 use std::path::PathBuf;
 
@@ -13,9 +15,6 @@ pub fn is_absolute_path(path: OsString) -> Option<PathBuf> {
 }
 
 #[cfg(all(unix, not(target_os = "redox")))]
-extern crate libc;
-
-#[cfg(all(unix, not(target_os = "redox")))]
 mod target_unix_not_redox {
 
 use std::env;
@@ -24,8 +23,6 @@ use std::mem;
 use std::os::unix::ffi::OsStringExt;
 use std::path::PathBuf;
 use std::ptr;
-
-use super::libc;
 
 // https://github.com/rust-lang/rust/blob/master/src/libstd/sys/unix/os.rs#L498
 pub fn home_dir() -> Option<PathBuf> {
@@ -72,9 +69,6 @@ pub fn home_dir() -> Option<PathBuf> {
 
 #[cfg(all(unix, not(target_os = "redox")))]
 pub use self::target_unix_not_redox::home_dir;
-
-#[cfg(target_os = "redox")]
-extern crate redox_users;
 
 #[cfg(target_os = "redox")]
 mod target_redox {
@@ -132,9 +126,6 @@ pub fn user_dirs(home_dir_path: &Path) -> HashMap<String, PathBuf> {
 pub use self::target_unix_not_mac::{user_dir, user_dirs};
 
 #[cfg(target_os = "windows")]
-extern crate winapi;
-
-#[cfg(target_os = "windows")]
 mod target_windows {
 
 use std::ffi::OsString;
@@ -143,9 +134,8 @@ use std::path::PathBuf;
 use std::ptr;
 use std::slice;
 
-use super::winapi;
-use super::winapi::shared::winerror;
-use super::winapi::um::{combaseapi, knownfolders, shlobj, shtypes, winbase, winnt};
+use winapi::shared::winerror;
+use winapi::um::{combaseapi, knownfolders, shlobj, shtypes, winbase, winnt};
 
 pub fn known_folder(folder_id: shtypes::REFKNOWNFOLDERID) -> Option<PathBuf> {
     unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,9 @@
 //! - the [Standard Directories](https://developer.apple.com/library/content/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW6) on macOS.
 
 #![deny(missing_docs)]
+#![warn(rust_2018_idioms)]
 
-#[macro_use]
-extern crate cfg_if;
+use cfg_if::cfg_if;
 
 use std::path::PathBuf;
 
@@ -30,7 +30,7 @@ cfg_if! {
         use wasm as sys;
     } else {
         mod lin;
-        use lin as sys;
+        use crate::lin as sys;
     }
 }
 
@@ -252,21 +252,21 @@ pub fn video_dir() -> Option<PathBuf> {
 mod tests {
     #[test]
     fn test_dirs() {
-        println!("home_dir:       {:?}", ::home_dir());
-        println!("cache_dir:      {:?}", ::cache_dir());
-        println!("config_dir:     {:?}", ::config_dir());
-        println!("data_dir:       {:?}", ::data_dir());
-        println!("data_local_dir: {:?}", ::data_local_dir());
-        println!("executable_dir: {:?}", ::executable_dir());
-        println!("runtime_dir:    {:?}", ::runtime_dir());
-        println!("audio_dir:      {:?}", ::audio_dir());
-        println!("home_dir:       {:?}", ::desktop_dir());
-        println!("cache_dir:      {:?}", ::document_dir());
-        println!("config_dir:     {:?}", ::download_dir());
-        println!("font_dir:       {:?}", ::font_dir());
-        println!("picture_dir:    {:?}", ::picture_dir());
-        println!("public_dir:     {:?}", ::public_dir());
-        println!("template_dir:   {:?}", ::template_dir());
-        println!("video_dir:      {:?}", ::video_dir());
+        println!("home_dir:       {:?}", crate::home_dir());
+        println!("cache_dir:      {:?}", crate::cache_dir());
+        println!("config_dir:     {:?}", crate::config_dir());
+        println!("data_dir:       {:?}", crate::data_dir());
+        println!("data_local_dir: {:?}", crate::data_local_dir());
+        println!("executable_dir: {:?}", crate::executable_dir());
+        println!("runtime_dir:    {:?}", crate::runtime_dir());
+        println!("audio_dir:      {:?}", crate::audio_dir());
+        println!("home_dir:       {:?}", crate::desktop_dir());
+        println!("cache_dir:      {:?}", crate::document_dir());
+        println!("config_dir:     {:?}", crate::download_dir());
+        println!("font_dir:       {:?}", crate::font_dir());
+        println!("picture_dir:    {:?}", crate::picture_dir());
+        println!("public_dir:     {:?}", crate::public_dir());
+        println!("template_dir:   {:?}", crate::template_dir());
+        println!("video_dir:      {:?}", crate::video_dir());
     }
 }

--- a/src/lin.rs
+++ b/src/lin.rs
@@ -1,5 +1,3 @@
-extern crate dirs_sys_next;
-
 use std::env;
 use std::path::PathBuf;
 
@@ -28,7 +26,7 @@ pub fn video_dir()      -> Option<PathBuf> { dirs_sys_next::user_dir("VIDEOS") }
 mod tests {
     #[test]
     fn test_file_user_dirs_exists() {
-        let user_dirs_file = ::config_dir().unwrap().join("user-dirs.dirs");
+        let user_dirs_file = crate::config_dir().unwrap().join("user-dirs.dirs");
         println!("{:?} exists: {:?}", user_dirs_file, user_dirs_file.exists());
     }
 }

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -1,5 +1,3 @@
-extern crate dirs_sys_next;
-
 use std::path::PathBuf;
 
 pub fn home_dir()       -> Option<PathBuf> { dirs_sys_next::home_dir() }

--- a/src/win.rs
+++ b/src/win.rs
@@ -1,5 +1,3 @@
-extern crate dirs_sys_next;
-
 use std::path::PathBuf;
 
 pub fn home_dir()       -> Option<PathBuf> { dirs_sys_next::known_folder_profile() }


### PR DESCRIPTION
I want to do the migration after we publish the release to keep compatible
for existing users of dirs.