### PR TITLE
change mac config directory from ~/Library/Preferences to ~/Library/Application Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ dirs_next::audio_dir();
 dirs_next::config_dir();
 // Lin: Some(/home/alice/.config)
 // Win: Some(C:\Users\Alice\AppData\Roaming)
-// Mac: Some(/Users/Alice/Library/Preferences)
+// Mac: Some(/Users/Alice/Library/Application Support)
 
 dirs_next::executable_dir();
 // Lin: Some(/home/alice/.local/bin)
@@ -86,7 +86,7 @@ use `ProjectDirs` of the [directories-next] project instead.**
 | ---------------- | ------------------------------------------------------------------------------------------------ | --------------------------------- | ------------------------------------------- |
 | `home_dir`       | `Some($HOME)`                                                                                    | `Some({FOLDERID_Profile})`        | `Some($HOME)`                               |
 | `cache_dir`      | `Some($XDG_CACHE_HOME)`         or `Some($HOME`/.cache`)`                                        | `Some({FOLDERID_LocalAppData})`   | `Some($HOME`/Library/Caches`)`              |
-| `config_dir`     | `Some($XDG_CONFIG_HOME)`        or `Some($HOME`/.config`)`                                       | `Some({FOLDERID_RoamingAppData})` | `Some($HOME`/Library/Preferences`)`         |
+| `config_dir`     | `Some($XDG_CONFIG_HOME)`        or `Some($HOME`/.config`)`                                       | `Some({FOLDERID_RoamingAppData})` | `Some($HOME`/Library/Application Support`)`         |
 | `data_dir`       | `Some($XDG_DATA_HOME)`          or `Some($HOME`/.local/share`)`                                  | `Some({FOLDERID_RoamingAppData})` | `Some($HOME`/Library/Application Support`)` |
 | `data_local_dir` | `Some($XDG_DATA_HOME)`          or `Some($HOME`/.local/share`)`                                  | `Some({FOLDERID_LocalAppData})`   | `Some($HOME`/Library/Application Support`)` |
 | `executable_dir` | `Some($XDG_BIN_HOME`/../bin`)`  or `Some($XDG_DATA_HOME`/../bin`)` or `Some($HOME`/.local/bin`)` | `None`                            | `None`                                      |

--- a/directories/README.md
+++ b/directories/README.md
@@ -37,7 +37,7 @@ if let Some(proj_dirs) = ProjectDirs::from("com", "Foo Corp",  "Bar App") {
     proj_dirs.config_dir();
     // Lin: /home/alice/.config/barapp
     // Win: C:\Users\Alice\AppData\Roaming\Foo Corp\Bar App\config
-    // Mac: /Users/Alice/Library/Preferences/com.Foo-Corp.Bar-App
+    // Mac: /Users/Alice/Library/Application Support/com.Foo-Corp.Bar-App
 }
 
 if let Some(base_dirs) = BaseDirs::new() {
@@ -91,7 +91,7 @@ or project, use `ProjectDirs` instead.
 | ---------------- | ----------------------------------------------------------------------------------------------- | --------------------------- | ----------------------------------- |
 | `home_dir`       | `$HOME`                                                                                         | `{FOLDERID_Profile}`        | `$HOME`                             |
 | `cache_dir`      | `$XDG_CACHE_HOME`              or `$HOME`/.cache                                                | `{FOLDERID_LocalAppData}`   | `$HOME`/Library/Caches              |
-| `config_dir`     | `$XDG_CONFIG_HOME`             or `$HOME`/.config                                               | `{FOLDERID_RoamingAppData}` | `$HOME`/Library/Preferences         |
+| `config_dir`     | `$XDG_CONFIG_HOME`             or `$HOME`/.config                                               | `{FOLDERID_RoamingAppData}` | `$HOME`/Library/Application Support         |
 | `data_dir`       | `$XDG_DATA_HOME`               or `$HOME`/.local/share                                          | `{FOLDERID_RoamingAppData}` | `$HOME`/Library/Application Support |
 | `data_local_dir` | `$XDG_DATA_HOME`               or `$HOME`/.local/share                                          | `{FOLDERID_LocalAppData}`   | `$HOME`/Library/Application Support |
 | `executable_dir` | `Some($XDG_BIN_HOME`/../bin`)` or `Some($XDG_DATA_HOME`/../bin`)` or `Some($HOME`/.local/bin`)` | `None`                      | `None`                              |
@@ -124,7 +124,7 @@ which are derived from the standard directories.
 | Function name    | Value on Linux                                                                     | Value on Windows                                    | Value on macOS                                       |
 | ---------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------- | ---------------------------------------------------- |
 | `cache_dir`      | `$XDG_CACHE_HOME`/`<project_path>`        or `$HOME`/.cache/`<project_path>`       | `{FOLDERID_LocalAppData}`/`<project_path>`/cache    | `$HOME`/Library/Caches/`<project_path>`              |
-| `config_dir`     | `$XDG_CONFIG_HOME`/`<project_path>`       or `$HOME`/.config/`<project_path>`      | `{FOLDERID_RoamingAppData}`/`<project_path>`/config | `$HOME`/Library/Preferences/`<project_path>`         |
+| `config_dir`     | `$XDG_CONFIG_HOME`/`<project_path>`       or `$HOME`/.config/`<project_path>`      | `{FOLDERID_RoamingAppData}`/`<project_path>`/config | `$HOME`/Library/Application Support/`<project_path>`         |
 | `data_dir`       | `$XDG_DATA_HOME`/`<project_path>`         or `$HOME`/.local/share/`<project_path>` | `{FOLDERID_RoamingAppData}`/`<project_path>`/data   | `$HOME`/Library/Application Support/`<project_path>` |
 | `data_local_dir` | `$XDG_DATA_HOME`/`<project_path>`         or `$HOME`/.local/share/`<project_path>` | `{FOLDERID_LocalAppData}`/`<project_path>`/data     | `$HOME`/Library/Application Support/`<project_path>` |
 | `runtime_dir`    | `Some($XDG_RUNTIME_DIR`/`_project_path_)`                                          | `None`                                              | `None`                                               |

--- a/directories/src/lib.rs
+++ b/directories/src/lib.rs
@@ -50,7 +50,7 @@ cfg_if! {
 ///     base_dirs.config_dir();
 ///     // Linux:   /home/alice/.config
 ///     // Windows: C:\Users\Alice\AppData\Roaming
-///     // macOS:   /Users/Alice/Library/Preferences
+///     // macOS:   /Users/Alice/Library/Application Support
 /// }
 /// ```
 #[derive(Debug, Clone)]
@@ -114,7 +114,7 @@ pub struct UserDirs {
 ///     proj_dirs.config_dir();
 ///     // Linux:   /home/alice/.config/barapp
 ///     // Windows: C:\Users\Alice\AppData\Roaming\Foo Corp\Bar App
-///     // macOS:   /Users/Alice/Library/Preferences/com.Foo-Corp.Bar-App
+///     // macOS:   /Users/Alice/Library/Application Support/com.Foo-Corp.Bar-App
 /// }
 /// ```
 #[derive(Debug, Clone)]
@@ -183,7 +183,8 @@ impl BaseDirs {
     /// |Platform | Value                                 | Example                          |
     /// | ------- | ------------------------------------- | -------------------------------- |
     /// | Linux   | `$XDG_CONFIG_HOME` or `$HOME`/.config | /home/alice/.config              |
-    /// | macOS   | `$HOME`/Library/Preferences           | /Users/Alice/Library/Preferences |
+    /// | macOS   | `$HOME`/Library/Application Support           |
+    /// /Users/Alice/Library/Application Support |
     /// | Windows | `{FOLDERID_RoamingAppData}`           | C:\Users\Alice\AppData\Roaming   |
     pub fn config_dir(&self) -> &Path {
         self.config_dir.as_path()
@@ -400,7 +401,7 @@ impl ProjectDirs {
     /// |Platform | Value                                                                   | Example                                                |
     /// | ------- | ----------------------------------------------------------------------- | ------------------------------------------------------ |
     /// | Linux   | `$XDG_CONFIG_HOME`/`_project_path_` or `$HOME`/.config/`_project_path_` | /home/alice/.config/barapp                             |
-    /// | macOS   | `$HOME`/Library/Preferences/`_project_path_`                            | /Users/Alice/Library/Preferences/com.Foo-Corp.Bar-App  |
+    /// | macOS   | `$HOME`/Library/Application Support/`_project_path_`                            | /Users/Alice/Library/Application Support/com.Foo-Corp.Bar-App  |
     /// | Windows | `{FOLDERID_RoamingAppData}`\\`_project_path_`\\config                   | C:\Users\Alice\AppData\Roaming\Foo Corp\Bar App\config |
     pub fn config_dir(&self) -> &Path {
         self.config_dir.as_path()

--- a/directories/src/mac.rs
+++ b/directories/src/mac.rs
@@ -9,7 +9,7 @@ use ProjectDirs;
 pub fn base_dirs() -> Option<BaseDirs> {
     if let Some(home_dir)  = dirs_sys_next::home_dir() {
         let cache_dir      = home_dir.join("Library/Caches");
-        let config_dir     = home_dir.join("Library/Preferences");
+        let config_dir     = home_dir.join("Library/Application Support");
         let data_dir       = home_dir.join("Library/Application Support");
         let data_local_dir = data_dir.clone();
 
@@ -60,7 +60,7 @@ pub fn user_dirs() -> Option<UserDirs> {
 pub fn project_dirs_from_path(project_path: PathBuf) -> Option<ProjectDirs> {
     if let Some(home_dir)  = dirs_sys_next::home_dir() {
         let cache_dir      = home_dir.join("Library/Caches").join(&project_path);
-        let config_dir     = home_dir.join("Library/Preferences").join(&project_path);
+        let config_dir     = home_dir.join("Library/Application Support").join(&project_path);
         let data_dir       = home_dir.join("Library/Application Support").join(&project_path);
         let data_local_dir = data_dir.clone();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ pub fn cache_dir() -> Option<PathBuf> {
 /// |Platform | Value                                 | Example                          |
 /// | ------- | ------------------------------------- | -------------------------------- |
 /// | Linux   | `$XDG_CONFIG_HOME` or `$HOME`/.config | /home/alice/.config              |
-/// | macOS   | `$HOME`/Library/Preferences           | /Users/Alice/Library/Preferences |
+/// | macOS   | `$HOME`/Library/Application Support           | /Users/Alice/Library/Application Support |
 /// | Windows | `{FOLDERID_RoamingAppData}`           | C:\Users\Alice\AppData\Roaming   |
 pub fn config_dir() -> Option<PathBuf> {
     sys::config_dir()

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 pub fn home_dir()       -> Option<PathBuf> { dirs_sys_next::home_dir() }
 pub fn cache_dir()      -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Caches")) }
-pub fn config_dir()     -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Preferences")) }
+pub fn config_dir()     -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Application Support")) }
 pub fn data_dir()       -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Application Support")) }
 pub fn data_local_dir() -> Option<PathBuf> { data_dir() }
 pub fn executable_dir() -> Option<PathBuf> { None }


### PR DESCRIPTION
In reference to [this issue](https://github.com/xdg-rs/dirs/issues/21)

Care should be given to whether this is a breaking change, and what version this should go in, but this should be the base change