### PR TITLE
dirs-sys: disable redox_users default features

### DIFF
--- a/dirs-sys/Cargo.toml
+++ b/dirs-sys/Cargo.toml
@@ -15,7 +15,7 @@ maintenance = { status = "as-is" }
 libc = "0.2"
 
 [target.'cfg(target_os = "redox")'.dependencies]
-redox_users = "0.3.0"
+redox_users = { version = "0.3.0", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["knownfolders", "objbase", "shlobj", "winbase", "winerror"] }


### PR DESCRIPTION
This avoids a dependency on rust-argon2, which isn't necessary for
dirs-sys's usage of the redox_users crate.

This also matches a change in the original dirs-sys crate.