### PR TITLE
Migrate wasm.rs to Rust 2018.

### DIFF
--- a/directories/src/wasm.rs
+++ b/directories/src/wasm.rs
@@ -2,9 +2,9 @@
 
 use std::path::PathBuf;
 
-use BaseDirs;
-use UserDirs;
-use ProjectDirs;
+use crate::BaseDirs;
+use crate::UserDirs;
+use crate::ProjectDirs;
 
 pub fn base_dirs() -> Option<BaseDirs> { None }
 pub fn user_dirs() -> Option<UserDirs> { None }


### PR DESCRIPTION
Add `crate::` qualifiers to directories/src/wasm.rs so that it compiles
on wasm targets.