### PR TITLE
Add XDG_STATE_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ use `ProjectDirs` of the [directories-next] project instead.**
 | `data_local_dir` | `Some($XDG_DATA_HOME)`          or `Some($HOME`/.local/share`)`                                  | `Some({FOLDERID_LocalAppData})`   | `Some($HOME`/Library/Application Support`)` |
 | `executable_dir` | `Some($XDG_BIN_HOME`/../bin`)`  or `Some($XDG_DATA_HOME`/../bin`)` or `Some($HOME`/.local/bin`)` | `None`                            | `None`                                      |
 | `runtime_dir`    | `Some($XDG_RUNTIME_DIR)`        or `None`                                                        | `None`                            | `None`                                      |
+| `state_dir`      | `Some($XDG_STATE_HOME)`         or `Some($HOME`/.local/state`)`                                  | `None`                            | `None`                                      |
 | `audio_dir`      | `Some(XDG_MUSIC_DIR)`           or `None`                                                        | `Some({FOLDERID_Music})`          | `Some($HOME`/Music/`)`                      |
 | `desktop_dir`    | `Some(XDG_DESKTOP_DIR)`         or `None`                                                        | `Some({FOLDERID_Desktop})`        | `Some($HOME`/Desktop/`)`                    |
 | `document_dir`   | `Some(XDG_DOCUMENTS_DIR)`       or `None`                                                        | `Some({FOLDERID_Documents})`      | `Some($HOME`/Documents/`)`                  |

--- a/directories/src/lib.rs
+++ b/directories/src/lib.rs
@@ -60,6 +60,7 @@ pub struct BaseDirs {
     data_local_dir: PathBuf,
     executable_dir: Option<PathBuf>,
     runtime_dir: Option<PathBuf>,
+    state_dir: Option<PathBuf>,
 }
 
 /// `UserDirs` provides paths of user-facing standard directories, following the conventions of the operating system the library is running on.
@@ -122,6 +123,7 @@ pub struct ProjectDirs {
     data_dir: PathBuf,
     data_local_dir: PathBuf,
     runtime_dir: Option<PathBuf>,
+    state_dir: Option<PathBuf>,
 }
 
 impl BaseDirs {
@@ -222,6 +224,18 @@ impl BaseDirs {
     /// | Windows | –                  | –               |
     pub fn runtime_dir(&self) -> Option<&Path> {
         self.runtime_dir.as_ref().map(|p| p.as_path())
+    }
+    /// Returns the path to the user's application state directory.
+    ///
+    /// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
+    ///
+    /// |Platform | Value                                     | Example                |
+    /// | ------- | ----------------------------------------- | ---------------------- |
+    /// | Linux   | `$XDG_STATE_HOME` or `$HOME`/.local/state | /home/alice/.local/bin |
+    /// | macOS   | –                                         | –                      |
+    /// | Windows | –                                         | –                      |
+    pub fn state_dir(&self) -> Option<&Path> {
+        self.state_dir.as_ref().map(|p| p.as_path())
     }
 }
 
@@ -429,6 +443,18 @@ impl ProjectDirs {
     /// | Windows | –                                   | –                     |
     pub fn runtime_dir(&self) -> Option<&Path> {
         self.runtime_dir.as_ref().map(|p| p.as_path())
+    }
+    /// Returns the path to the project's application state directory.
+    ///
+    /// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
+    ///
+    /// |Platform | Value                                     | Example                |
+    /// | ------- | ----------------------------------------- | ---------------------- |
+    /// | Linux   | `$XDG_STATE_HOME` or `$HOME`/.local/state | /home/alice/.local/bin |
+    /// | macOS   | –                                         | –                      |
+    /// | Windows | –                                         | –                      |
+    pub fn state_dir(&self) -> Option<&Path> {
+        self.state_dir.as_ref().map(|p| p.as_path())
     }
 }
 

--- a/directories/src/lin.rs
+++ b/directories/src/lin.rs
@@ -25,6 +25,9 @@ pub fn base_dirs() -> Option<BaseDirs> {
                 new_dir.push("bin");
                 new_dir
             });
+        let state_dir = env::var_os("XDG_STATE_HOME")
+            .and_then(dirs_sys_next::is_absolute_path)
+            .unwrap_or_else(|| home_dir.join(".local/state"));
 
         let base_dirs = BaseDirs {
             home_dir,
@@ -34,6 +37,7 @@ pub fn base_dirs() -> Option<BaseDirs> {
             data_local_dir,
             executable_dir: Some(executable_dir),
             runtime_dir,
+            state_dir: Some(state_dir),
         };
         Some(base_dirs)
     } else {
@@ -84,8 +88,19 @@ pub fn project_dirs_from_path(project_path: PathBuf) -> Option<ProjectDirs> {
         let data_local_dir = data_dir.clone();
         let runtime_dir =
             env::var_os("XDG_RUNTIME_DIR").and_then(dirs_sys_next::is_absolute_path).map(|o| o.join(&project_path));
+        let state_dir = env::var_os("XDG_STATE_HOME")
+            .and_then(dirs_sys_next::is_absolute_path)
+            .unwrap_or_else(|| home_dir.join(".local/state"));
 
-        let project_dirs = ProjectDirs { project_path, cache_dir, config_dir, data_dir, data_local_dir, runtime_dir };
+        let project_dirs = ProjectDirs {
+            project_path,
+            cache_dir,
+            config_dir,
+            data_dir,
+            data_local_dir,
+            runtime_dir,
+            state_dir: Some(state_dir),
+        };
         Some(project_dirs)
     } else {
         None

--- a/directories/src/mac.rs
+++ b/directories/src/mac.rs
@@ -19,6 +19,7 @@ pub fn base_dirs() -> Option<BaseDirs> {
             data_local_dir,
             executable_dir: None,
             runtime_dir: None,
+            state_dir: None,
         };
         Some(base_dirs)
     } else {
@@ -62,8 +63,15 @@ pub fn project_dirs_from_path(project_path: PathBuf) -> Option<ProjectDirs> {
         let data_dir = config_dir.clone();
         let data_local_dir = data_dir.clone();
 
-        let project_dirs =
-            ProjectDirs { project_path, cache_dir, config_dir, data_dir, data_local_dir, runtime_dir: None };
+        let project_dirs = ProjectDirs {
+            project_path,
+            cache_dir,
+            config_dir,
+            data_dir,
+            data_local_dir,
+            runtime_dir: None,
+            state_dir: None,
+        };
         Some(project_dirs)
     } else {
         None

--- a/directories/src/win.rs
+++ b/directories/src/win.rs
@@ -21,6 +21,7 @@ pub fn base_dirs() -> Option<BaseDirs> {
             data_local_dir,
             executable_dir: None,
             runtime_dir: None,
+            state_dir: None,
         };
         Some(base_dirs)
     } else {
@@ -68,8 +69,15 @@ pub fn project_dirs_from_path(project_path: PathBuf) -> Option<ProjectDirs> {
         let config_dir = app_data_roaming.join("config");
         let data_dir = app_data_roaming.join("data");
 
-        let project_dirs =
-            ProjectDirs { project_path, cache_dir, config_dir, data_dir, data_local_dir, runtime_dir: None };
+        let project_dirs = ProjectDirs {
+            project_path,
+            cache_dir,
+            config_dir,
+            data_dir,
+            data_local_dir,
+            runtime_dir: None,
+            state_dir: None,
+        };
         Some(project_dirs)
     } else {
         None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! The _dirs-next_ crate is
 //!
-//! - a tiny library with a minimal API (16 functions)
+//! - a tiny library with a minimal API (17 functions)
 //! - that provides the platform-specific, user-accessible locations
 //! - for finding and storing configuration, cache and other data
 //! - on Linux, Redox, Windows (≥ Vista) and macOS.
@@ -132,6 +132,18 @@ pub fn executable_dir() -> Option<PathBuf> {
 pub fn runtime_dir() -> Option<PathBuf> {
     sys::runtime_dir()
 }
+/// Returns the path to the user's application state directory.
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
+///
+/// |Platform | Value                                     | Example                |
+/// | ------- | ----------------------------------------- | ---------------------- |
+/// | Linux   | `$XDG_STATE_HOME` or `$HOME`/.local/state | /home/alice/.local/bin |
+/// | macOS   | –                                         | –                      |
+/// | Windows | –                                         | –                      |
+pub fn state_dir() -> Option<PathBuf> {
+    sys::state_dir()
+}
 
 /// Returns the path to the user's audio directory.
 ///
@@ -254,6 +266,7 @@ mod tests {
         println!("data_local_dir: {:?}", crate::data_local_dir());
         println!("executable_dir: {:?}", crate::executable_dir());
         println!("runtime_dir:    {:?}", crate::runtime_dir());
+        println!("state_dir:      {:?}", crate::state_dir());
         println!("audio_dir:      {:?}", crate::audio_dir());
         println!("home_dir:       {:?}", crate::desktop_dir());
         println!("cache_dir:      {:?}", crate::document_dir());

--- a/src/lin.rs
+++ b/src/lin.rs
@@ -34,6 +34,11 @@ pub fn executable_dir() -> Option<PathBuf> {
         })
     })
 }
+pub fn state_dir() -> Option<PathBuf> {
+    env::var_os("XDG_STATE_HOME")
+        .and_then(dirs_sys_next::is_absolute_path)
+        .or_else(|| home_dir().map(|h| h.join(".local/state")))
+}
 pub fn audio_dir() -> Option<PathBuf> {
     dirs_sys_next::user_dir("MUSIC")
 }

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -21,6 +21,9 @@ pub fn executable_dir() -> Option<PathBuf> {
 pub fn runtime_dir() -> Option<PathBuf> {
     None
 }
+pub fn state_dir() -> Option<PathBuf> {
+    None
+}
 pub fn audio_dir() -> Option<PathBuf> {
     home_dir().map(|h| h.join("Music"))
 }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -23,6 +23,9 @@ pub fn runtime_dir() -> Option<PathBuf> {
 pub fn executable_dir() -> Option<PathBuf> {
     None
 }
+pub fn state_dir() -> Option<PathBuf> {
+    None
+}
 pub fn audio_dir() -> Option<PathBuf> {
     None
 }

--- a/src/win.rs
+++ b/src/win.rs
@@ -21,6 +21,9 @@ pub fn executable_dir() -> Option<PathBuf> {
 pub fn runtime_dir() -> Option<PathBuf> {
     None
 }
+pub fn state_dir() -> Option<PathBuf> {
+    None
+}
 pub fn audio_dir() -> Option<PathBuf> {
     dirs_sys_next::known_folder_music()
 }


### PR DESCRIPTION
Not released yet, but it's already [part of the spec](https://gitlab.freedesktop.org/xdg/xdg-specs/-/commit/4f2884e16db35f2962d9b64312917c81be5cb54b): `$XDG_STATE_HOME`.

I added support for it in this crate by copy-pasting and following existing patterns as much as possible. As it's not officially released yet, maybe it should be hidden behind a feature flag?

I don't know anything about Windows and Mac, so I simply answered that question with `None`. I think implementing it for these platforms can be done in a future work. (I wouldn't want to do it since I can't test it.)