### PR TITLE
Remove a duplicate marked job that bors considers them failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,11 +103,3 @@ jobs:
     steps:
       - name: mark the job as a success
         run: exit 0
-  end-failure:
-    name: bors build finished
-    runs-on: ubuntu-latest
-    needs: [build, checks, rustfmt, minimum-rust-version]
-    if: github.actor == 'bors[bot]' && (failure() || cancelled())
-    steps:
-      - name: mark the job as a failure
-        run: exit 1


### PR DESCRIPTION
Prompted by https://github.com/bors-ng/bors-ng/issues/1121

This is the same problem as https://github.com/bors-ng/bors-ng/issues/1115#issuecomment-751793439

Instead of silently ignoring cancelled statuses, bors will consider them failures now.