### PR TITLE
use std::fs::read instead of custom function

### DIFF
--- a/dirs-sys/src/xdg_user_dirs.rs
+++ b/dirs-sys/src/xdg_user_dirs.rs
@@ -1,20 +1,19 @@
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fs;
-use std::io::{self, Read};
 use std::os::unix::ffi::OsStringExt;
 use std::path::{Path, PathBuf};
 use std::str;
 
 /// Returns all XDG user directories obtained from $(XDG_CONFIG_HOME)/user-dirs.dirs.
 pub fn all(home_dir_path: &Path, user_dir_file_path: &Path) -> HashMap<String, PathBuf> {
-    let bytes = read_all(user_dir_file_path).unwrap_or_default();
+    let bytes = fs::read(user_dir_file_path).unwrap_or_default();
     parse_user_dirs(home_dir_path, None, &bytes)
 }
 
 /// Returns a single XDG user directory obtained from $(XDG_CONFIG_HOME)/user-dirs.dirs.
 pub fn single(home_dir_path: &Path, user_dir_file_path: &Path, user_dir_name: &str) -> HashMap<String, PathBuf> {
-    let bytes = read_all(user_dir_file_path).unwrap_or_default();
+    let bytes = fs::read(user_dir_file_path).unwrap_or_default();
     parse_user_dirs(home_dir_path, Some(user_dir_name), &bytes)
 }
 
@@ -84,14 +83,6 @@ fn parse_user_dirs(home_dir: &Path, user_dir: Option<&str>, bytes: &[u8]) -> Has
     }
 
     user_dirs
-}
-
-/// Reads the entire contents of a file into a byte vector.
-fn read_all(path: &Path) -> io::Result<Vec<u8>> {
-    let mut file = fs::File::open(path)?;
-    let mut bytes = Vec::with_capacity(1024);
-    file.read_to_end(&mut bytes)?;
-    Ok(bytes)
 }
 
 /// Returns bytes before and after first occurrence of separator.


### PR DESCRIPTION
Note that this changes the buffer size: `std::fs::read` uses the file
length + 1 byte, instead of the hardcoded 1024 bytes currently in use.

Fixes #51.