### PR TITLE
Add a cargo feature to disable the `getpwuid_r` fallback.

### DIFF
--- a/directories/Cargo.toml
+++ b/directories/Cargo.toml
@@ -31,6 +31,18 @@ maintenance = { status = "passively-maintained" }
 [dependencies.dirs-sys-next]
 version = "0.1"
 path = "../dirs-sys"
+default-features = false
+
+[features]
+default = ["dirs-sys-next/default"]
+
+# Default features, except follow the behavior of libxdg-basedir, which does
+# not fall back to `getpwuid_r`.
+default_xdg = ["dirs-sys-next/default_xdg"]
+
+# Enable this to have dirs-sys call `getpwuid_r` as a fallback in case `HOME`
+# is unset or empty.
+getpwuid = ["dirs-sys-next/getpwuid"]
 
 [dev-dependencies]
 bencher = "0.1.5"

--- a/dirs-sys/Cargo.toml
+++ b/dirs-sys/Cargo.toml
@@ -19,10 +19,21 @@ include = [
 maintenance = { status = "as-is" }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc = { version = "0.2", optional = true }
 
 [target.'cfg(target_os = "redox")'.dependencies]
 redox_users = { version = "0.4.0", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["knownfolders", "objbase", "shlobj", "winbase", "winerror"] }
+
+[features]
+default = ["getpwuid"]
+
+# Default features, except follow the behavior of libxdg-basedir, which does
+# not fall back to `getpwuid_r`.
+default_xdg = []
+
+# Enable this to have dirs-sys call `getpwuid_r` as a fallback in case `HOME`
+# is unset or empty.
+getpwuid = ["libc"]

--- a/dirs-sys/src/lib.rs
+++ b/dirs-sys/src/lib.rs
@@ -138,62 +138,63 @@ mod target_windows {
     use winapi::shared::winerror;
     use winapi::um::{combaseapi, knownfolders, shlobj, shtypes, winbase, winnt};
 
-    pub fn known_folder(folder_id: shtypes::REFKNOWNFOLDERID) -> Option<PathBuf> {
-        unsafe {
-            let mut path_ptr: winnt::PWSTR = ptr::null_mut();
-            let result = shlobj::SHGetKnownFolderPath(folder_id, 0, ptr::null_mut(), &mut path_ptr);
-            if result == winerror::S_OK {
-                let len = winbase::lstrlenW(path_ptr) as usize;
-                let path = slice::from_raw_parts(path_ptr, len);
-                let ostr: OsString = OsStringExt::from_wide(path);
-                combaseapi::CoTaskMemFree(path_ptr as *mut winapi::ctypes::c_void);
-                Some(PathBuf::from(ostr))
-            } else {
-                None
-            }
+    /// # Safety
+    ///
+    /// `folder_id` must be one of the `FOLDERID_*` values in `knownfolders`.
+    pub unsafe fn known_folder(folder_id: shtypes::REFKNOWNFOLDERID) -> Option<PathBuf> {
+        let mut path_ptr: winnt::PWSTR = ptr::null_mut();
+        let result = shlobj::SHGetKnownFolderPath(folder_id, 0, ptr::null_mut(), &mut path_ptr);
+        if result == winerror::S_OK {
+            let len = winbase::lstrlenW(path_ptr) as usize;
+            let path = slice::from_raw_parts(path_ptr, len);
+            let ostr: OsString = OsStringExt::from_wide(path);
+            combaseapi::CoTaskMemFree(path_ptr as *mut winapi::ctypes::c_void);
+            Some(PathBuf::from(ostr))
+        } else {
+            None
         }
     }
 
     pub fn known_folder_profile() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Profile)
+        unsafe { known_folder(&knownfolders::FOLDERID_Profile) }
     }
 
     pub fn known_folder_roaming_app_data() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_RoamingAppData)
+        unsafe { known_folder(&knownfolders::FOLDERID_RoamingAppData) }
     }
 
     pub fn known_folder_local_app_data() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_LocalAppData)
+        unsafe { known_folder(&knownfolders::FOLDERID_LocalAppData) }
     }
 
     pub fn known_folder_music() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Music)
+        unsafe { known_folder(&knownfolders::FOLDERID_Music) }
     }
 
     pub fn known_folder_desktop() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Desktop)
+        unsafe { known_folder(&knownfolders::FOLDERID_Desktop) }
     }
 
     pub fn known_folder_documents() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Documents)
+        unsafe { known_folder(&knownfolders::FOLDERID_Documents) }
     }
 
     pub fn known_folder_downloads() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Downloads)
+        unsafe { known_folder(&knownfolders::FOLDERID_Downloads) }
     }
 
     pub fn known_folder_pictures() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Pictures)
+        unsafe { known_folder(&knownfolders::FOLDERID_Pictures) }
     }
 
     pub fn known_folder_public() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Public)
+        unsafe { known_folder(&knownfolders::FOLDERID_Public) }
     }
     pub fn known_folder_templates() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Templates)
+        unsafe { known_folder(&knownfolders::FOLDERID_Templates) }
     }
     pub fn known_folder_videos() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Videos)
+        unsafe { known_folder(&knownfolders::FOLDERID_Videos) }
     }
 }
 

--- a/dirs/Cargo.toml
+++ b/dirs/Cargo.toml
@@ -31,3 +31,15 @@ maintenance = { status = "passively-maintained" }
 [dependencies.dirs-sys-next]
 version = "0.1"
 path = "../dirs-sys"
+default-features = false
+
+[features]
+default = ["dirs-sys-next/default"]
+
+# Default features, except follow the behavior of libxdg-basedir, which does
+# not fall back to `getpwuid_r`.
+default_xdg = ["dirs-sys-next/default_xdg"]
+
+# Enable this to have dirs-sys call `getpwuid_r` as a fallback in case `HOME`
+# is unset or empty.
+getpwuid = ["dirs-sys-next/getpwuid"]


### PR DESCRIPTION
Currently dirs_next and directories_next fall back to calling
`getpwuid_r` when the `HOME` environment variable is not set, on most
Unix-like platforms.

This is undesirable for at least some users, because such behavior is not
specified in the [XDG Base Directory Specification] and differs from the
behavior of the widely used libxdg-basedir. And, calling `getpwuid_r` means
depending on a part of libc which, on some platforms, calls `dlopen` and
runs third-party code that uses filesystem and networking in-process,
which can create problems for some sandboxing scenarios.

This PR puts `getpwuid_r` under control of a feature flag, enabled by
default to maintain compatibility with existing users of the crate, but
which can be disabled by users who don't desire the `getpwuid_r` behavior.

[XDG Base Directory Specification]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html