### PR TITLE
Migrate from winapi to windows-sys.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          rustup toolchain install 1.34.0
+          rustup toolchain install 1.48.0
           rustup default 1.34.0
           rustup target add \
             x86_64-pc-windows-gnu \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           rustup toolchain install 1.48.0
-          rustup default 1.34.0
+          rustup default 1.48.0
           rustup target add \
             x86_64-pc-windows-gnu \
             x86_64-apple-darwin \

--- a/directories/README.md
+++ b/directories/README.md
@@ -28,7 +28,7 @@ Other platforms are also supported; they use the Linux conventions.
 
 ## Minimum Rust version policy
 
-The minimal required version of Rust is `1.34.0`.
+The minimal required version of Rust is `1.48.0`.
 
 We may bump the Rust version in major and minor releases (`x`/`y` in `x.y.z`).
 Changing the Rust version will be written in the CHANGELOG.

--- a/dirs-sys/Cargo.toml
+++ b/dirs-sys/Cargo.toml
@@ -25,11 +25,10 @@ libc = "0.2"
 redox_users = { version = "0.4.0", default-features = false }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.36.0"
+version = "0.42.0"
 features = [
     "Win32_Foundation",
     "Win32_Globalization",
     "Win32_System_Com",
     "Win32_UI_Shell",
-    "Storage",
 ]

--- a/dirs-sys/Cargo.toml
+++ b/dirs-sys/Cargo.toml
@@ -25,7 +25,7 @@ libc = "0.2"
 redox_users = { version = "0.4.0", default-features = false }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.42.0"
+version = "0.45.0"
 features = [
     "Win32_Foundation",
     "Win32_Globalization",

--- a/dirs-sys/Cargo.toml
+++ b/dirs-sys/Cargo.toml
@@ -24,5 +24,12 @@ libc = "0.2"
 [target.'cfg(target_os = "redox")'.dependencies]
 redox_users = { version = "0.4.0", default-features = false }
 
-[target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["knownfolders", "objbase", "shlobj", "winbase", "winerror"] }
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.36.0"
+features = [
+    "Win32_Foundation",
+    "Win32_Globalization",
+    "Win32_System_Com",
+    "Win32_UI_Shell",
+    "Storage",
+]

--- a/dirs-sys/README.md
+++ b/dirs-sys/README.md
@@ -22,7 +22,7 @@ Other platforms are also supported; they use the Linux conventions.
 
 ## Minimum Rust version policy
 
-The minimal required version of Rust is `1.34.0`^.
+The minimal required version of Rust is `1.48.0`^.
 
 We may bump the Rust version in major and minor releases (`x`/`y` in `x.y.z`).
 Changing the Rust version will be written in the CHANGELOG.

--- a/dirs-sys/src/lib.rs
+++ b/dirs-sys/src/lib.rs
@@ -135,62 +135,60 @@ mod target_windows {
     use windows_sys::Win32::System::Com::CoTaskMemFree;
     use windows_sys::Win32::UI::Shell;
 
-    pub fn known_folder(folder_id: *const GUID) -> Option<PathBuf> {
-        unsafe {
-            let mut path_ptr: PWSTR = ptr::null_mut();
-            let result = Shell::SHGetKnownFolderPath(folder_id, 0, 0, &mut path_ptr);
-            if result == S_OK {
-                let len = lstrlenW(path_ptr) as usize;
-                let path = slice::from_raw_parts(path_ptr, len);
-                let ostr: OsString = OsStringExt::from_wide(path);
-                CoTaskMemFree(path_ptr as *mut std::os::raw::c_void);
-                Some(PathBuf::from(ostr))
-            } else {
-                None
-            }
+    pub unsafe fn known_folder(folder_id: *const GUID) -> Option<PathBuf> {
+        let mut path_ptr: PWSTR = ptr::null_mut();
+        let result = Shell::SHGetKnownFolderPath(folder_id, 0, 0, &mut path_ptr);
+        if result == S_OK {
+            let len = lstrlenW(path_ptr) as usize;
+            let path = slice::from_raw_parts(path_ptr, len);
+            let ostr: OsString = OsStringExt::from_wide(path);
+            CoTaskMemFree(path_ptr as *mut std::os::raw::c_void);
+            Some(PathBuf::from(ostr))
+        } else {
+            None
         }
     }
 
     pub fn known_folder_profile() -> Option<PathBuf> {
-        known_folder(&Shell::FOLDERID_Profile)
+        unsafe { known_folder(&Shell::FOLDERID_Profile) }
     }
 
     pub fn known_folder_roaming_app_data() -> Option<PathBuf> {
-        known_folder(&Shell::FOLDERID_RoamingAppData)
+        unsafe { known_folder(&Shell::FOLDERID_RoamingAppData) }
     }
 
     pub fn known_folder_local_app_data() -> Option<PathBuf> {
-        known_folder(&Shell::FOLDERID_LocalAppData)
+        unsafe { known_folder(&Shell::FOLDERID_LocalAppData) }
     }
 
     pub fn known_folder_music() -> Option<PathBuf> {
-        known_folder(&Shell::FOLDERID_Music)
+        unsafe { known_folder(&Shell::FOLDERID_Music) }
     }
 
     pub fn known_folder_desktop() -> Option<PathBuf> {
-        known_folder(&Shell::FOLDERID_Desktop)
+        unsafe { known_folder(&Shell::FOLDERID_Desktop) }
     }
 
     pub fn known_folder_documents() -> Option<PathBuf> {
-        known_folder(&Shell::FOLDERID_Documents)
+        unsafe { known_folder(&Shell::FOLDERID_Documents) }
     }
 
     pub fn known_folder_downloads() -> Option<PathBuf> {
-        known_folder(&Shell::FOLDERID_Downloads)
+        unsafe { known_folder(&Shell::FOLDERID_Downloads) }
     }
 
     pub fn known_folder_pictures() -> Option<PathBuf> {
-        known_folder(&Shell::FOLDERID_Pictures)
+        unsafe { known_folder(&Shell::FOLDERID_Pictures) }
     }
 
     pub fn known_folder_public() -> Option<PathBuf> {
-        known_folder(&Shell::FOLDERID_Public)
+        unsafe { known_folder(&Shell::FOLDERID_Public) }
     }
     pub fn known_folder_templates() -> Option<PathBuf> {
-        known_folder(&Shell::FOLDERID_Templates)
+        unsafe { known_folder(&Shell::FOLDERID_Templates) }
     }
     pub fn known_folder_videos() -> Option<PathBuf> {
-        known_folder(&Shell::FOLDERID_Videos)
+        unsafe { known_folder(&Shell::FOLDERID_Videos) }
     }
 }
 

--- a/dirs-sys/src/lib.rs
+++ b/dirs-sys/src/lib.rs
@@ -128,18 +128,22 @@ mod target_windows {
     use std::ptr;
     use std::slice;
 
-    use winapi::shared::winerror;
-    use winapi::um::{combaseapi, knownfolders, shlobj, shtypes, winbase, winnt};
+    use windows_sys::core::GUID;
+    use windows_sys::core::PWSTR;
+    use windows_sys::Win32::Foundation::S_OK;
+    use windows_sys::Win32::Globalization::lstrlenW;
+    use windows_sys::Win32::System::Com::CoTaskMemFree;
+    use windows_sys::Win32::UI::Shell;
 
-    pub fn known_folder(folder_id: shtypes::REFKNOWNFOLDERID) -> Option<PathBuf> {
+    pub fn known_folder(folder_id: *const GUID) -> Option<PathBuf> {
         unsafe {
-            let mut path_ptr: winnt::PWSTR = ptr::null_mut();
-            let result = shlobj::SHGetKnownFolderPath(folder_id, 0, ptr::null_mut(), &mut path_ptr);
-            if result == winerror::S_OK {
-                let len = winbase::lstrlenW(path_ptr) as usize;
+            let mut path_ptr: PWSTR = ptr::null_mut();
+            let result = Shell::SHGetKnownFolderPath(folder_id, 0, 0, &mut path_ptr);
+            if result == S_OK {
+                let len = lstrlenW(path_ptr) as usize;
                 let path = slice::from_raw_parts(path_ptr, len);
                 let ostr: OsString = OsStringExt::from_wide(path);
-                combaseapi::CoTaskMemFree(path_ptr as *mut winapi::ctypes::c_void);
+                CoTaskMemFree(path_ptr as *mut std::os::raw::c_void);
                 Some(PathBuf::from(ostr))
             } else {
                 None
@@ -148,45 +152,45 @@ mod target_windows {
     }
 
     pub fn known_folder_profile() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Profile)
+        known_folder(&Shell::FOLDERID_Profile)
     }
 
     pub fn known_folder_roaming_app_data() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_RoamingAppData)
+        known_folder(&Shell::FOLDERID_RoamingAppData)
     }
 
     pub fn known_folder_local_app_data() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_LocalAppData)
+        known_folder(&Shell::FOLDERID_LocalAppData)
     }
 
     pub fn known_folder_music() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Music)
+        known_folder(&Shell::FOLDERID_Music)
     }
 
     pub fn known_folder_desktop() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Desktop)
+        known_folder(&Shell::FOLDERID_Desktop)
     }
 
     pub fn known_folder_documents() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Documents)
+        known_folder(&Shell::FOLDERID_Documents)
     }
 
     pub fn known_folder_downloads() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Downloads)
+        known_folder(&Shell::FOLDERID_Downloads)
     }
 
     pub fn known_folder_pictures() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Pictures)
+        known_folder(&Shell::FOLDERID_Pictures)
     }
 
     pub fn known_folder_public() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Public)
+        known_folder(&Shell::FOLDERID_Public)
     }
     pub fn known_folder_templates() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Templates)
+        known_folder(&Shell::FOLDERID_Templates)
     }
     pub fn known_folder_videos() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Videos)
+        known_folder(&Shell::FOLDERID_Videos)
     }
 }
 

--- a/dirs/README.md
+++ b/dirs/README.md
@@ -28,7 +28,7 @@ Other platforms are also supported; they use the Linux conventions.
 
 ## Minimum Rust version policy
 
-The minimal required version of Rust is `1.34.0`.
+The minimal required version of Rust is `1.48.0`.
 
 We may bump the Rust version in major and minor releases (`x`/`y` in `x.y.z`).
 Changing the Rust version will be written in the CHANGELOG.


### PR DESCRIPTION
This PR migrates dirs-sys-next from winapi to windows-sys.

Windows-sys is actively maintained, by Microsoft, and has recently
started to be adopted in the ecosystem; mio, parking_lot, wasmtime,
and others have moved to windows-sys.

Migrating dirs-sys-next to windows-sys will help me remove one more of
Wasmtime's transitive dependencies on winapi.