### PR TITLE
dirs-sys: migrate winapi to windows-sys

### DIFF
--- a/dirs-sys/Cargo.toml
+++ b/dirs-sys/Cargo.toml
@@ -25,4 +25,9 @@ libc = "0.2"
 redox_users = { version = "0.4.0", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["knownfolders", "objbase", "shlobj", "winbase", "winerror"] }
+windows-sys = { version = "0.45.0", features = [
+    "Win32_UI_Shell",
+    "Win32_Foundation",
+    "Win32_Globalization",
+    "Win32_System_Com",
+] }

--- a/dirs-sys/src/lib.rs
+++ b/dirs-sys/src/lib.rs
@@ -142,6 +142,7 @@ mod target_windows {
                 combaseapi::CoTaskMemFree(path_ptr as *mut winapi::ctypes::c_void);
                 Some(PathBuf::from(ostr))
             } else {
+                combaseapi::CoTaskMemFree(path_ptr as *mut winapi::ctypes::c_void);
                 None
             }
         }

--- a/dirs-sys/src/lib.rs
+++ b/dirs-sys/src/lib.rs
@@ -122,72 +122,73 @@ pub use self::target_unix_not_mac::{user_dir, user_dirs};
 #[cfg(target_os = "windows")]
 mod target_windows {
 
+    use std::ffi::c_void;
     use std::ffi::OsString;
     use std::os::windows::ffi::OsStringExt;
     use std::path::PathBuf;
-    use std::ptr;
     use std::slice;
 
-    use winapi::shared::winerror;
-    use winapi::um::{combaseapi, knownfolders, shlobj, shtypes, winbase, winnt};
+    use windows::Win32;
+    use windows::Win32::UI::Shell;
 
-    pub fn known_folder(folder_id: shtypes::REFKNOWNFOLDERID) -> Option<PathBuf> {
+    pub fn known_folder(folder_id: windows::core::GUID) -> Option<PathBuf> {
         unsafe {
-            let mut path_ptr: winnt::PWSTR = ptr::null_mut();
-            let result = shlobj::SHGetKnownFolderPath(folder_id, 0, ptr::null_mut(), &mut path_ptr);
-            if result == winerror::S_OK {
-                let len = winbase::lstrlenW(path_ptr) as usize;
+            let mut path_ptr: windows::core::PWSTR = std::ptr::null_mut();
+            let result =
+                Shell::SHGetKnownFolderPath(&folder_id, 0, Win32::Foundation::HANDLE::default(), &mut path_ptr);
+            if result == 0 {
+                let len = windows::Win32::Globalization::lstrlenW(path_ptr) as usize;
                 let path = slice::from_raw_parts(path_ptr, len);
                 let ostr: OsString = OsStringExt::from_wide(path);
-                combaseapi::CoTaskMemFree(path_ptr as *mut winapi::ctypes::c_void);
+                windows::Win32::System::Com::CoTaskMemFree(path_ptr as *const c_void);
                 Some(PathBuf::from(ostr))
             } else {
-                combaseapi::CoTaskMemFree(path_ptr as *mut winapi::ctypes::c_void);
+                windows::Win32::System::Com::CoTaskMemFree(path_ptr as *const c_void);
                 None
             }
         }
     }
 
     pub fn known_folder_profile() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Profile)
+        known_folder(Shell::FOLDERID_Profile)
     }
 
     pub fn known_folder_roaming_app_data() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_RoamingAppData)
+        known_folder(Shell::FOLDERID_RoamingAppData)
     }
 
     pub fn known_folder_local_app_data() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_LocalAppData)
+        known_folder(Shell::FOLDERID_LocalAppData)
     }
 
     pub fn known_folder_music() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Music)
+        known_folder(Shell::FOLDERID_Music)
     }
 
     pub fn known_folder_desktop() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Desktop)
+        known_folder(Shell::FOLDERID_Desktop)
     }
 
     pub fn known_folder_documents() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Documents)
+        known_folder(Shell::FOLDERID_Documents)
     }
 
     pub fn known_folder_downloads() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Downloads)
+        known_folder(Shell::FOLDERID_Downloads)
     }
 
     pub fn known_folder_pictures() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Pictures)
+        known_folder(Shell::FOLDERID_Pictures)
     }
 
     pub fn known_folder_public() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Public)
+        known_folder(Shell::FOLDERID_Public)
     }
     pub fn known_folder_templates() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Templates)
+        known_folder(Shell::FOLDERID_Templates)
     }
     pub fn known_folder_videos() -> Option<PathBuf> {
-        known_folder(&knownfolders::FOLDERID_Videos)
+        known_folder(Shell::FOLDERID_Videos)
     }
 }
 


### PR DESCRIPTION
Cherry-picked the following commits from dirs-dev, bringing this fork in sync with it (except for our own changes):
- https://github.com/dirs-dev/dirs-sys-rs/commit/03a62f0235c6c8bc27a8b86339ad5148cac77f8e
- https://github.com/dirs-dev/dirs-sys-rs/commit/044360b995d68d70e33eb5391778765c4c8dbd01