### PR TITLE
dirs: add preference_dir, state_dir, & adjust executable_dir

### DIFF
--- a/dirs/README.md
+++ b/dirs/README.md
@@ -87,26 +87,26 @@ dirs_next::executable_dir();
 **If you want to compute the location of cache, config or data directories for your own application or project,
 use `ProjectDirs` of the [directories-next] project instead.**
 
-| Function name    | Value on Linux/Redox                                                                             | Value on Windows                  | Value on macOS                              |
-| ---------------- | ------------------------------------------------------------------------------------------------ | --------------------------------- | ------------------------------------------- |
-| `home_dir`       | `Some($HOME)`                                                                                    | `Some({FOLDERID_Profile})`        | `Some($HOME)`                               |
-| `cache_dir`      | `Some($XDG_CACHE_HOME)`         or `Some($HOME`/.cache`)`                                        | `Some({FOLDERID_LocalAppData})`   | `Some($HOME`/Library/Caches`)`              |
-| `config_dir`     | `Some($XDG_CONFIG_HOME)`        or `Some($HOME`/.config`)`                                       | `Some({FOLDERID_RoamingAppData})` | `Some($HOME`/Library/Application Support`)` |
-| `preference_dir` | `Some($XDG_CONFIG_HOME)`        or `Some($HOME`/.config`)`                                       | `Some({FOLDERID_RoamingAppData})` | `Some($HOME`/Library/Preferences`)`         |
-| `data_dir`       | `Some($XDG_DATA_HOME)`          or `Some($HOME`/.local/share`)`                                  | `Some({FOLDERID_RoamingAppData})` | `Some($HOME`/Library/Application Support`)` |
-| `data_local_dir` | `Some($XDG_DATA_HOME)`          or `Some($HOME`/.local/share`)`                                  | `Some({FOLDERID_LocalAppData})`   | `Some($HOME`/Library/Application Support`)` |
-| `executable_dir` | `Some($XDG_BIN_HOME`/../bin`)`  or `Some($XDG_DATA_HOME`/../bin`)` or `Some($HOME`/.local/bin`)` | `None`                            | `None`                                      |
-| `runtime_dir`    | `Some($XDG_RUNTIME_DIR)`        or `None`                                                        | `None`                            | `None`                                      |
-| `state_dir`      | `Some($XDG_STATE_HOME)`         or `Some($HOME`/.local/state`)`                                  | `None`                            | `None`                                      |
-| `audio_dir`      | `Some(XDG_MUSIC_DIR)`           or `None`                                                        | `Some({FOLDERID_Music})`          | `Some($HOME`/Music/`)`                      |
-| `desktop_dir`    | `Some(XDG_DESKTOP_DIR)`         or `None`                                                        | `Some({FOLDERID_Desktop})`        | `Some($HOME`/Desktop/`)`                    |
-| `document_dir`   | `Some(XDG_DOCUMENTS_DIR)`       or `None`                                                        | `Some({FOLDERID_Documents})`      | `Some($HOME`/Documents/`)`                  |
-| `download_dir`   | `Some(XDG_DOWNLOAD_DIR)`        or `None`                                                        | `Some({FOLDERID_Downloads})`      | `Some($HOME`/Downloads/`)`                  |
-| `font_dir`       | `Some($XDG_DATA_HOME`/fonts/`)` or `Some($HOME`/.local/share/fonts/`)`                           | `None`                            | `Some($HOME`/Library/Fonts/`)`              |
-| `picture_dir`    | `Some(XDG_PICTURES_DIR)`        or `None`                                                        | `Some({FOLDERID_Pictures})`       | `Some($HOME`/Pictures/`)`                   |
-| `public_dir`     | `Some(XDG_PUBLICSHARE_DIR)`     or `None`                                                        | `Some({FOLDERID_Public})`         | `Some($HOME`/Public/`)`                     |
-| `template_dir`   | `Some(XDG_TEMPLATES_DIR)`       or `None`                                                        | `Some({FOLDERID_Templates})`      | `None`                                      |
-| `video_dir`      | `Some(XDG_VIDEOS_DIR)`          or `None`                                                        | `Some({FOLDERID_Videos})`         | `Some($HOME`/Movies/`)`                     |
+| Function name    | Value on Linux/Redox                                                   | Value on Windows                  | Value on macOS                              |
+| ---------------- | ---------------------------------------------------------------------- | --------------------------------- | ------------------------------------------- |
+| `home_dir`       | `Some($HOME)`                                                          | `Some({FOLDERID_Profile})`        | `Some($HOME)`                               |
+| `cache_dir`      | `Some($XDG_CACHE_HOME)`         or `Some($HOME`/.cache`)`              | `Some({FOLDERID_LocalAppData})`   | `Some($HOME`/Library/Caches`)`              |
+| `config_dir`     | `Some($XDG_CONFIG_HOME)`        or `Some($HOME`/.config`)`             | `Some({FOLDERID_RoamingAppData})` | `Some($HOME`/Library/Application Support`)` |
+| `preference_dir` | `Some($XDG_CONFIG_HOME)`        or `Some($HOME`/.config`)`             | `Some({FOLDERID_RoamingAppData})` | `Some($HOME`/Library/Preferences`)`         |
+| `data_dir`       | `Some($XDG_DATA_HOME)`          or `Some($HOME`/.local/share`)`        | `Some({FOLDERID_RoamingAppData})` | `Some($HOME`/Library/Application Support`)` |
+| `data_local_dir` | `Some($XDG_DATA_HOME)`          or `Some($HOME`/.local/share`)`        | `Some({FOLDERID_LocalAppData})`   | `Some($HOME`/Library/Application Support`)` |
+| `executable_dir` | `Some($XDG_BIN_HOME)`           or `Some($HOME`/.local/bin`)`          | `None`                            | `None`                                      |
+| `runtime_dir`    | `Some($XDG_RUNTIME_DIR)`        or `None`                              | `None`                            | `None`                                      |
+| `state_dir`      | `Some($XDG_STATE_HOME)`         or `Some($HOME`/.local/state`)`        | `None`                            | `None`                                      |
+| `audio_dir`      | `Some(XDG_MUSIC_DIR)`           or `None`                              | `Some({FOLDERID_Music})`          | `Some($HOME`/Music/`)`                      |
+| `desktop_dir`    | `Some(XDG_DESKTOP_DIR)`         or `None`                              | `Some({FOLDERID_Desktop})`        | `Some($HOME`/Desktop/`)`                    |
+| `document_dir`   | `Some(XDG_DOCUMENTS_DIR)`       or `None`                              | `Some({FOLDERID_Documents})`      | `Some($HOME`/Documents/`)`                  |
+| `download_dir`   | `Some(XDG_DOWNLOAD_DIR)`        or `None`                              | `Some({FOLDERID_Downloads})`      | `Some($HOME`/Downloads/`)`                  |
+| `font_dir`       | `Some($XDG_DATA_HOME`/fonts/`)` or `Some($HOME`/.local/share/fonts/`)` | `None`                            | `Some($HOME`/Library/Fonts/`)`              |
+| `picture_dir`    | `Some(XDG_PICTURES_DIR)`        or `None`                              | `Some({FOLDERID_Pictures})`       | `Some($HOME`/Pictures/`)`                   |
+| `public_dir`     | `Some(XDG_PUBLICSHARE_DIR)`     or `None`                              | `Some({FOLDERID_Public})`         | `Some($HOME`/Public/`)`                     |
+| `template_dir`   | `Some(XDG_TEMPLATES_DIR)`       or `None`                              | `Some({FOLDERID_Templates})`      | `None`                                      |
+| `video_dir`      | `Some(XDG_VIDEOS_DIR)`          or `None`                              | `Some({FOLDERID_Videos})`         | `Some($HOME`/Movies/`)`                     |
 
 ## Comparison
 

--- a/dirs/README.md
+++ b/dirs/README.md
@@ -92,6 +92,7 @@ use `ProjectDirs` of the [directories-next] project instead.**
 | `home_dir`       | `Some($HOME)`                                                                                    | `Some({FOLDERID_Profile})`        | `Some($HOME)`                               |
 | `cache_dir`      | `Some($XDG_CACHE_HOME)`         or `Some($HOME`/.cache`)`                                        | `Some({FOLDERID_LocalAppData})`   | `Some($HOME`/Library/Caches`)`              |
 | `config_dir`     | `Some($XDG_CONFIG_HOME)`        or `Some($HOME`/.config`)`                                       | `Some({FOLDERID_RoamingAppData})` | `Some($HOME`/Library/Application Support`)` |
+| `preference_dir` | `Some($XDG_CONFIG_HOME)`        or `Some($HOME`/.config`)`                                       | `Some({FOLDERID_RoamingAppData})` | `Some($HOME`/Library/Preferences`)`         |
 | `data_dir`       | `Some($XDG_DATA_HOME)`          or `Some($HOME`/.local/share`)`                                  | `Some({FOLDERID_RoamingAppData})` | `Some($HOME`/Library/Application Support`)` |
 | `data_local_dir` | `Some($XDG_DATA_HOME)`          or `Some($HOME`/.local/share`)`                                  | `Some({FOLDERID_LocalAppData})`   | `Some($HOME`/Library/Application Support`)` |
 | `executable_dir` | `Some($XDG_BIN_HOME`/../bin`)`  or `Some($XDG_DATA_HOME`/../bin`)` or `Some($HOME`/.local/bin`)` | `None`                            | `None`                                      |

--- a/dirs/README.md
+++ b/dirs/README.md
@@ -97,6 +97,7 @@ use `ProjectDirs` of the [directories-next] project instead.**
 | `data_local_dir` | `Some($XDG_DATA_HOME)`          or `Some($HOME`/.local/share`)`                                  | `Some({FOLDERID_LocalAppData})`   | `Some($HOME`/Library/Application Support`)` |
 | `executable_dir` | `Some($XDG_BIN_HOME`/../bin`)`  or `Some($XDG_DATA_HOME`/../bin`)` or `Some($HOME`/.local/bin`)` | `None`                            | `None`                                      |
 | `runtime_dir`    | `Some($XDG_RUNTIME_DIR)`        or `None`                                                        | `None`                            | `None`                                      |
+| `state_dir`      | `Some($XDG_STATE_HOME)`         or `Some($HOME`/.local/state`)`                                  | `None`                            | `None`                                      |
 | `audio_dir`      | `Some(XDG_MUSIC_DIR)`           or `None`                                                        | `Some({FOLDERID_Music})`          | `Some($HOME`/Music/`)`                      |
 | `desktop_dir`    | `Some(XDG_DESKTOP_DIR)`         or `None`                                                        | `Some({FOLDERID_Desktop})`        | `Some($HOME`/Desktop/`)`                    |
 | `document_dir`   | `Some(XDG_DOCUMENTS_DIR)`       or `None`                                                        | `Some({FOLDERID_Documents})`      | `Some($HOME`/Documents/`)`                  |

--- a/dirs/src/lib.rs
+++ b/dirs/src/lib.rs
@@ -134,6 +134,9 @@ pub fn executable_dir() -> Option<PathBuf> {
 }
 /// Returns the path to the user's runtime directory.
 ///
+/// The runtime directory contains transient, non-essential data (like sockets or named pipes) that
+/// is expected to be cleared when the user's session ends.
+///
 /// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
 ///
 /// |Platform | Value              | Example         |

--- a/dirs/src/lib.rs
+++ b/dirs/src/lib.rs
@@ -1,6 +1,6 @@
 //! The _dirs-next_ crate is
 //!
-//! - a tiny library with a minimal API (17 functions)
+//! - a tiny library with a minimal API (18 functions)
 //! - that provides the platform-specific, user-accessible locations
 //! - for finding and storing configuration, cache and other data
 //! - on Linux, Redox, Windows (≥ Vista) and macOS.
@@ -144,6 +144,22 @@ pub fn executable_dir() -> Option<PathBuf> {
 pub fn runtime_dir() -> Option<PathBuf> {
     sys::runtime_dir()
 }
+/// Returns the path to the user's state directory.
+///
+/// The state directory contains data that should be retained between sessions (unlike the runtime
+/// directory), but may not be important/portable enough to be synchronized across machines (unlike
+/// the config/preferences/data directories).
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
+///
+/// |Platform | Value                                     | Example                  |
+/// | ------- | ----------------------------------------- | ------------------------ |
+/// | Linux   | `$XDG_STATE_HOME` or `$HOME`/.local/state | /home/alice/.local/state |
+/// | macOS   | –                                         | –                        |
+/// | Windows | –                                         | –                        |
+pub fn state_dir() -> Option<PathBuf> {
+    sys::state_dir()
+}
 
 /// Returns the path to the user's audio directory.
 ///
@@ -260,6 +276,7 @@ mod tests {
     #[test]
     fn test_dirs() {
         println!("home_dir:       {:?}", crate::home_dir());
+        println!();
         println!("cache_dir:      {:?}", crate::cache_dir());
         println!("config_dir:     {:?}", crate::config_dir());
         println!("preference_dir: {:?}", crate::preference_dir());
@@ -267,8 +284,10 @@ mod tests {
         println!("data_local_dir: {:?}", crate::data_local_dir());
         println!("executable_dir: {:?}", crate::executable_dir());
         println!("runtime_dir:    {:?}", crate::runtime_dir());
+        println!("state_dir:      {:?}", crate::state_dir());
+        println!();
         println!("audio_dir:      {:?}", crate::audio_dir());
-        println!("home_dir:       {:?}", crate::desktop_dir());
+        println!("desktop_dir:    {:?}", crate::desktop_dir());
         println!("cache_dir:      {:?}", crate::document_dir());
         println!("config_dir:     {:?}", crate::download_dir());
         println!("font_dir:       {:?}", crate::font_dir());

--- a/dirs/src/lib.rs
+++ b/dirs/src/lib.rs
@@ -1,6 +1,6 @@
 //! The _dirs-next_ crate is
 //!
-//! - a tiny library with a minimal API (16 functions)
+//! - a tiny library with a minimal API (17 functions)
 //! - that provides the platform-specific, user-accessible locations
 //! - for finding and storing configuration, cache and other data
 //! - on Linux, Redox, Windows (≥ Vista) and macOS.
@@ -76,13 +76,25 @@ pub fn cache_dir() -> Option<PathBuf> {
 ///
 /// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
 ///
+/// |Platform | Value                                 | Example                                  |
+/// | ------- | ------------------------------------- | ---------------------------------------- |
+/// | Linux   | `$XDG_CONFIG_HOME` or `$HOME`/.config | /home/alice/.config                      |
+/// | macOS   | `$HOME`/Library/Application Support   | /Users/Alice/Library/Application Support |
+/// | Windows | `{FOLDERID_RoamingAppData}`           | C:\Users\Alice\AppData\Roaming           |
+pub fn config_dir() -> Option<PathBuf> {
+    sys::config_dir()
+}
+/// Returns the path to the user's preference directory.
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
+///
 /// |Platform | Value                                 | Example                          |
 /// | ------- | ------------------------------------- | -------------------------------- |
 /// | Linux   | `$XDG_CONFIG_HOME` or `$HOME`/.config | /home/alice/.config              |
-/// | macOS   | `$HOME`/Library/Application Support   | /Users/Alice/Library/Application Support |
+/// | macOS   | `$HOME`/Library/Preferences           | /Users/Alice/Library/Preferences |
 /// | Windows | `{FOLDERID_RoamingAppData}`           | C:\Users\Alice\AppData\Roaming   |
-pub fn config_dir() -> Option<PathBuf> {
-    sys::config_dir()
+pub fn preference_dir() -> Option<PathBuf> {
+    sys::preference_dir()
 }
 /// Returns the path to the user's data directory.
 ///
@@ -250,6 +262,7 @@ mod tests {
         println!("home_dir:       {:?}", crate::home_dir());
         println!("cache_dir:      {:?}", crate::cache_dir());
         println!("config_dir:     {:?}", crate::config_dir());
+        println!("preference_dir: {:?}", crate::preference_dir());
         println!("data_dir:       {:?}", crate::data_dir());
         println!("data_local_dir: {:?}", crate::data_local_dir());
         println!("executable_dir: {:?}", crate::executable_dir());

--- a/dirs/src/lin.rs
+++ b/dirs/src/lin.rs
@@ -14,6 +14,9 @@ pub fn config_dir() -> Option<PathBuf> {
         .and_then(dirs_sys_next::is_absolute_path)
         .or_else(|| home_dir().map(|h| h.join(".config")))
 }
+pub fn preference_dir() -> Option<PathBuf> {
+    config_dir()
+}
 pub fn data_dir() -> Option<PathBuf> {
     env::var_os("XDG_DATA_HOME")
         .and_then(dirs_sys_next::is_absolute_path)

--- a/dirs/src/lin.rs
+++ b/dirs/src/lin.rs
@@ -30,13 +30,9 @@ pub fn runtime_dir() -> Option<PathBuf> {
     env::var_os("XDG_RUNTIME_DIR").and_then(dirs_sys_next::is_absolute_path)
 }
 pub fn executable_dir() -> Option<PathBuf> {
-    env::var_os("XDG_BIN_HOME").and_then(dirs_sys_next::is_absolute_path).or_else(|| {
-        data_dir().map(|mut e| {
-            e.pop();
-            e.push("bin");
-            e
-        })
-    })
+    env::var_os("XDG_BIN_HOME")
+        .and_then(dirs_sys_next::is_absolute_path)
+        .or_else(|| home_dir().map(|h| h.join(".local/bin")))
 }
 pub fn state_dir() -> Option<PathBuf> {
     env::var_os("XDG_STATE_HOME")

--- a/dirs/src/lin.rs
+++ b/dirs/src/lin.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 pub fn home_dir() -> Option<PathBuf> {
     dirs_sys_next::home_dir()
 }
+
 pub fn cache_dir() -> Option<PathBuf> {
     env::var_os("XDG_CACHE_HOME")
         .and_then(dirs_sys_next::is_absolute_path)
@@ -37,6 +38,12 @@ pub fn executable_dir() -> Option<PathBuf> {
         })
     })
 }
+pub fn state_dir() -> Option<PathBuf> {
+    env::var_os("XDG_STATE_HOME")
+        .and_then(dirs_sys_next::is_absolute_path)
+        .or_else(|| home_dir().map(|h| h.join(".local/state")))
+}
+
 pub fn audio_dir() -> Option<PathBuf> {
     dirs_sys_next::user_dir("MUSIC")
 }

--- a/dirs/src/mac.rs
+++ b/dirs/src/mac.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 pub fn home_dir() -> Option<PathBuf> {
     dirs_sys_next::home_dir()
 }
+
 pub fn cache_dir() -> Option<PathBuf> {
     home_dir().map(|h| h.join("Library/Caches"))
 }
@@ -24,6 +25,10 @@ pub fn executable_dir() -> Option<PathBuf> {
 pub fn runtime_dir() -> Option<PathBuf> {
     None
 }
+pub fn state_dir() -> Option<PathBuf> {
+    None
+}
+
 pub fn audio_dir() -> Option<PathBuf> {
     home_dir().map(|h| h.join("Music"))
 }

--- a/dirs/src/mac.rs
+++ b/dirs/src/mac.rs
@@ -9,6 +9,9 @@ pub fn cache_dir() -> Option<PathBuf> {
 pub fn config_dir() -> Option<PathBuf> {
     data_dir()
 }
+pub fn preference_dir() -> Option<PathBuf> {
+    home_dir().map(|h| h.join("Library/Preferences"))
+}
 pub fn data_dir() -> Option<PathBuf> {
     home_dir().map(|h| h.join("Library/Application Support"))
 }

--- a/dirs/src/wasm.rs
+++ b/dirs/src/wasm.rs
@@ -11,6 +11,9 @@ pub fn cache_dir() -> Option<PathBuf> {
 pub fn config_dir() -> Option<PathBuf> {
     None
 }
+pub fn preference_dir() -> Option<PathBuf> {
+    None
+}
 pub fn data_dir() -> Option<PathBuf> {
     None
 }

--- a/dirs/src/wasm.rs
+++ b/dirs/src/wasm.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 pub fn home_dir() -> Option<PathBuf> {
     None
 }
+
 pub fn cache_dir() -> Option<PathBuf> {
     None
 }
@@ -26,6 +27,10 @@ pub fn runtime_dir() -> Option<PathBuf> {
 pub fn executable_dir() -> Option<PathBuf> {
     None
 }
+pub fn state_dir() -> Option<PathBuf> {
+    None
+}
+
 pub fn audio_dir() -> Option<PathBuf> {
     None
 }

--- a/dirs/src/win.rs
+++ b/dirs/src/win.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 pub fn home_dir() -> Option<PathBuf> {
     dirs_sys_next::known_folder_profile()
 }
+
 pub fn data_dir() -> Option<PathBuf> {
     dirs_sys_next::known_folder_roaming_app_data()
 }
@@ -24,6 +25,10 @@ pub fn executable_dir() -> Option<PathBuf> {
 pub fn runtime_dir() -> Option<PathBuf> {
     None
 }
+pub fn state_dir() -> Option<PathBuf> {
+    None
+}
+
 pub fn audio_dir() -> Option<PathBuf> {
     dirs_sys_next::known_folder_music()
 }

--- a/dirs/src/win.rs
+++ b/dirs/src/win.rs
@@ -15,6 +15,9 @@ pub fn cache_dir() -> Option<PathBuf> {
 pub fn config_dir() -> Option<PathBuf> {
     data_dir()
 }
+pub fn preference_dir() -> Option<PathBuf> {
+    data_dir()
+}
 pub fn executable_dir() -> Option<PathBuf> {
     None
 }


### PR DESCRIPTION
Cherry-picked the following commits from dirs-dev, bringing this fork in sync with it (except for our own changes):
- https://github.com/dirs-dev/dirs-rs/commit/887e2ae55eef326bd3c0b5080e28acd9b9073490 (preference_dir parts)
- https://github.com/dirs-dev/dirs-rs/commit/8f14dfc8e58693664846b9ee88149250293f5c9c
- https://github.com/dirs-dev/dirs-rs/commit/0c63034fdc1b1ada5889834a8093e8d71ae2fbc5
- https://github.com/dirs-dev/dirs-rs/commit/f8843434bfe4125294d4c7bffecb857cbc7774a8